### PR TITLE
Move ReagentTest into a module-specific package

### DIFF
--- a/test/src/org/labkey/test/tests/reagent/ReagentTest.java
+++ b/test/src/org/labkey/test/tests/reagent/ReagentTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.labkey.test.tests;
+package org.labkey.test.tests.reagent;
 
 import org.junit.BeforeClass;
 import org.junit.Test;


### PR DESCRIPTION
#### Rationale
We had no TeamCity validation for branches in this module. To do so we need a 'reagent' suite.