### PR TITLE
Attempt to wait for reagent combo pre-select

### DIFF
--- a/test/src/org/labkey/test/tests/reagent/ReagentTest.java
+++ b/test/src/org/labkey/test/tests/reagent/ReagentTest.java
@@ -236,7 +236,8 @@ public class ReagentTest extends BaseWebDriverTest
         String lotNumber = "lot-" + Math.random();
 
         // reagent combo should pre-select the reagent we started with
-        assertEquals(reagentName, getComboBoxInput("Reagent:"));
+        waitFor(()-> reagentName.equals(getComboBoxInput("Reagent:")),
+                "reagent combo should pre-select the reagent we started with", WAIT_FOR_JAVASCRIPT);
         _extHelper.selectComboBoxItem("Manufacturer:", "Immunotech");
         _extHelper.setExtFormElementByLabel("Lot Number:", lotNumber);
         setComboBoxInput("CatalogNumber:", "IM2712X");


### PR DESCRIPTION
#### Rationale
Recent test failure (in which the equality assert failed, but the after- screencap/artifacts show the right value) suggests a race condition in the test.  This attempts to wait for the expected condition, and fail if it doesn't become equal in time.

#### Related Pull Requests


#### Changes

