### PR TITLE
Wait for Ext4 combo box to load display values

### DIFF
--- a/test/src/org/labkey/test/tests/reagent/ReagentTest.java
+++ b/test/src/org/labkey/test/tests/reagent/ReagentTest.java
@@ -321,6 +321,12 @@ public class ReagentTest extends BaseWebDriverTest
 
         Locator inputLoc = Locator.xpath("//input[contains(@class, 'x-form-field')]");
         WebElement inputEl = inputLoc.findElement(comboEl);
+        WebElement hiddenImput = Locator.xpath(".").precedingSibling("input").findElement(inputEl);
+        String hiddenValue = hiddenImput.getAttribute("value");
+        if (!hiddenValue.isBlank())
+        {
+            waitFor(() -> !getFormElement(inputEl).equals(hiddenValue), "Display values did not load", 1000);
+        }
         return getFormElement(inputEl);
     }
 


### PR DESCRIPTION
#### Rationale
This test fails intermittently when checking the initial value of Ext4 combo boxes because the display value takes a moment to appear.
```
org.junit.ComparisonFailure: expected:<[CCR7, PE-Cy7 (3D12)]> but was:<[1]>
  at org.junit.Assert.assertEquals(Assert.java:115)
  at org.junit.Assert.assertEquals(Assert.java:144)
  at org.labkey.test.tests.reagent.ReagentTest.testInsertLotAndTiter(ReagentTest.java:239)
```

#### Changes
* Wait for Ext4 combo box to load display values
