### PR TITLE
Remove SupportedDatabases property now that default is PostgreSQL-only

### DIFF
--- a/module.properties
+++ b/module.properties
@@ -10,4 +10,3 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
-SupportedDatabases: pgsql


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6067